### PR TITLE
add description to errors on registration screen

### DIFF
--- a/FindFriends.xcodeproj/project.pbxproj
+++ b/FindFriends.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		DD3A2E9F2B7D2F65006A3B8E /* UIView+AutoresizingMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3A2E9E2B7D2F65006A3B8E /* UIView+AutoresizingMask.swift */; };
 		DD3A2EA62B7E9447006A3B8E /* PrimeOrangeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3A2EA52B7E9447006A3B8E /* PrimeOrangeButton.swift */; };
 		DD3A2EA82B7E9836006A3B8E /* CaptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3A2EA72B7E9836006A3B8E /* CaptionButton.swift */; };
+		DDC2551B2BA2249F0037FA7E /* ErrorDescriptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC2551A2BA2249F0037FA7E /* ErrorDescriptionModel.swift */; };
 		DDCAC7C42B83C0BF00EC7D15 /* WhiteBorderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCAC7C32B83C0BF00EC7D15 /* WhiteBorderButton.swift */; };
 		DDCAC7C72B84FB7900EC7D15 /* UIFont+CustomFonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCAC7C62B84FB7900EC7D15 /* UIFont+CustomFonts.swift */; };
 		DDCAC7CC2B851EF500EC7D15 /* RegistrationTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCAC7CB2B851EF500EC7D15 /* RegistrationTextField.swift */; };
@@ -155,6 +156,7 @@
 		DD3A2E9E2B7D2F65006A3B8E /* UIView+AutoresizingMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AutoresizingMask.swift"; sourceTree = "<group>"; };
 		DD3A2EA52B7E9447006A3B8E /* PrimeOrangeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeOrangeButton.swift; sourceTree = "<group>"; };
 		DD3A2EA72B7E9836006A3B8E /* CaptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionButton.swift; sourceTree = "<group>"; };
+		DDC2551A2BA2249F0037FA7E /* ErrorDescriptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDescriptionModel.swift; sourceTree = "<group>"; };
 		DDCAC7C32B83C0BF00EC7D15 /* WhiteBorderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteBorderButton.swift; sourceTree = "<group>"; };
 		DDCAC7C62B84FB7900EC7D15 /* UIFont+CustomFonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+CustomFonts.swift"; sourceTree = "<group>"; };
 		DDCAC7CB2B851EF500EC7D15 /* RegistrationTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationTextField.swift; sourceTree = "<group>"; };
@@ -477,6 +479,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		DDC2551C2BA22B8E0037FA7E /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				DDC2551A2BA2249F0037FA7E /* ErrorDescriptionModel.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
 		DDCAC7CD2B851F4200EC7D15 /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -502,6 +512,7 @@
 		F301706E2B8CE45400A6921A /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				DDC2551C2BA22B8E0037FA7E /* Errors */,
 				F33B4C8A2B8FB9EE002D27B5 /* Dto */,
 				F30170632B8CDC9700A6921A /* Requests */,
 			);
@@ -813,6 +824,7 @@
 				CECC80F02B9898D600F4312B /* SelectPhotoViewController.swift in Sources */,
 				D86387D22B8A754100692535 /* RegistrationService.swift in Sources */,
 				84531D1A2B94C450002289C6 /* GenderSelectionViewController.swift in Sources */,
+				DDC2551B2BA2249F0037FA7E /* ErrorDescriptionModel.swift in Sources */,
 				D853CC282B7567AF00DA58D5 /* SceneDelegate.swift in Sources */,
 				F36F408E2B86435500B2082B /* NewPasswordSuccessViewController.swift in Sources */,
 				F36F40912B864B1E00B2082B /* NewPasswordView.swift in Sources */,

--- a/FindFriends/Common/Models/Network/Errors/ErrorDescriptionModel.swift
+++ b/FindFriends/Common/Models/Network/Errors/ErrorDescriptionModel.swift
@@ -1,0 +1,12 @@
+//
+//  ErrorModel.swift
+//  FindFriends
+//
+//  Created by Вадим Шишков on 13.03.2024.
+//
+
+import Foundation
+
+struct RegistrationErrorModel: Decodable {
+    let password: [String]
+}

--- a/FindFriends/Common/NetworkClient/NetworkClient.swift
+++ b/FindFriends/Common/NetworkClient/NetworkClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NetworkClientError: Error {
-    case httpStatusCode(Int)
+    case httpStatusCode(Int, Data)
     case urlRequestError(Error)
     case urlSessionError
     case parsingError
@@ -9,13 +9,17 @@ enum NetworkClientError: Error {
 
 protocol NetworkClient {
     @discardableResult
-    func send(request: NetworkRequest,
-              onResponse: @escaping (Result<Data, Error>) -> Void) -> NetworkTask?
+    func send(
+        request: NetworkRequest,
+        onResponse: @escaping (Result<Data, NetworkClientError>) -> Void
+    ) -> NetworkTask?
 
     @discardableResult
-    func send<T: Decodable>(request: NetworkRequest,
-                            type: T.Type,
-                            onResponse: @escaping (Result<T, Error>) -> Void) -> NetworkTask?
+    func send<T: Decodable>(
+        request: NetworkRequest,
+        type: T.Type,
+        onResponse: @escaping (Result<T, NetworkClientError>) -> Void
+    ) -> NetworkTask?
 }
 
 struct DefaultNetworkClient: NetworkClient {
@@ -30,42 +34,31 @@ struct DefaultNetworkClient: NetworkClient {
         self.decoder = decoder
         self.encoder = encoder
     }
-
+    
     @discardableResult
-    func send(request: NetworkRequest, onResponse: @escaping (Result<Data, Error>) -> Void) -> NetworkTask? {
+    func send(
+        request: NetworkRequest,
+        onResponse: @escaping (Result<Data, NetworkClientError>) -> Void
+    ) -> NetworkTask? {
+        
         guard let urlRequest = create(request: request) else { return nil }
 
-//        print("urlRequest: \(urlRequest.debugDescription)")
-//        print("urlRequest: \(urlRequest.httpMethod)")
-//        let str = String(decoding: urlRequest.httpBody ?? Data(), as: UTF8.self)
-//        print("urlRequest: \(str)")
-//        print("urlRequest: \(urlRequest.allHTTPHeaderFields)")
-//        
-
         let task = session.dataTask(with: urlRequest) { data, response, error in
-            guard let response = response as? HTTPURLResponse else {
-                onResponse(.failure(NetworkClientError.urlSessionError))
+            if let error {
+                onResponse(.failure(.urlRequestError(error)))
                 return
             }
             
-//            let strData = String(decoding: data!, as: UTF8.self)
-//            print("response: \(strData)")
-//            print("response: \(response.statusCode)")
+            guard let code = (response as? HTTPURLResponse)?.statusCode else { return }
             
-            guard 200 ..< 300 ~= response.statusCode else {
-                onResponse(.failure(NetworkClientError.httpStatusCode(response.statusCode)))
-                return
-            }
-
             if let data = data {
-                onResponse(.success(data))
-                return
-            } else if let error = error {
-                onResponse(.failure(NetworkClientError.urlRequestError(error)))
-                return
+                if 200..<300 ~= code {
+                    onResponse(.success(data))
+                } else {
+                    onResponse(.failure(.httpStatusCode(code, data)))
+                }
             } else {
-                assertionFailure("Unexpected condition!")
-                return
+                onResponse(.failure(.urlSessionError))
             }
         }
 
@@ -74,7 +67,12 @@ struct DefaultNetworkClient: NetworkClient {
     }
 
     @discardableResult
-    func send<T: Decodable>(request: NetworkRequest, type: T.Type, onResponse: @escaping (Result<T, Error>) -> Void) -> NetworkTask? {
+    func send<T: Decodable>(
+        request: NetworkRequest,
+        type: T.Type,
+        onResponse: @escaping (Result<T, NetworkClientError>) -> Void
+    ) -> NetworkTask? {
+        
         return send(request: request) { result in
             switch result {
             case let .success(data):
@@ -109,12 +107,12 @@ struct DefaultNetworkClient: NetworkClient {
         return urlRequest
     }
 
-    private func parse<T: Decodable>(data: Data, type _: T.Type, onResponse: @escaping (Result<T, Error>) -> Void) {
+    private func parse<T: Decodable>(data: Data, type _: T.Type, onResponse: @escaping (Result<T, NetworkClientError>) -> Void) {
         do {
             let response = try decoder.decode(T.self, from: data)
             onResponse(.success(response))
         } catch {
-            onResponse(.failure(NetworkClientError.parsingError))
+            onResponse(.failure(.parsingError))
         }
     }
 

--- a/FindFriends/Common/Services/Network/RegistrationService.swift
+++ b/FindFriends/Common/Services/Network/RegistrationService.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol RegistrationServiceProtocol {
     func createUser(
         _ dto: CreateUserRequestDto,
-        completion: @escaping (Result<CreateUserResponseDto, Error>) -> Void
+        completion: @escaping (Result<CreateUserResponseDto, NetworkClientError>) -> Void
     )
     func loginUser(
         _ dto: LoginRequestDto,
@@ -46,14 +46,14 @@ final class RegistrationService: RegistrationServiceProtocol {
     // MARK: - Public methods
     func createUser(
         _ dto: CreateUserRequestDto,
-        completion: @escaping (Result<CreateUserResponseDto, Error>) -> Void
+        completion: @escaping (Result<CreateUserResponseDto, NetworkClientError>) -> Void
     ) {
         let request = CreateUserRequest(dto: dto)
         networkClient.send(request: request, type: CreateUserResponseDto.self) { result in
             DispatchQueue.main.async {
                 switch result {
-                case let .success(data):
-                    completion(.success(data))
+                case let .success(user):
+                    completion(.success(user))
                 case let .failure(error):
                     completion(.failure(error))
                 }

--- a/FindFriends/Screens/Registration/Register/RegistrationViewModel.swift
+++ b/FindFriends/Screens/Registration/Register/RegistrationViewModel.swift
@@ -134,12 +134,26 @@ final class RegistrationViewModel {
         }
     }
     
-    private func showAlert(_ error: Error) {
+    private func showAlert(_ error: NetworkClientError) {
+        var description = ""
+        
+        switch error {
+        case let .httpStatusCode(code, data):
+            let model = try? JSONDecoder().decode(RegistrationErrorModel.self, from: data)
+            description = model?.password.joined(separator: " ") ?? ""
+        case .urlRequestError(let error):
+            assertionFailure("Ошибка составления запроса: \(error.localizedDescription)")
+        case .urlSessionError:
+            assertionFailure("Непредвиденная ошибка")
+        case .parsingError:
+            assertionFailure("Ошибка парсинга")
+        }
+        
         let alert = AlertModel(
             title: "Внимание",
-            message: error.localizedDescription,
+            message: description,
             buttons: [AlertButton(
-                text: "Ок",
+                text: "Понятно",
                 style: .cancel,
                 completion: { _ in })
             ],


### PR DESCRIPTION
Добавил показ ошибки в случае плохих паролей. Пока не придумал как обобщить всё это, как я понял на каждую ошибку нужна будет своя модель. И как их различать фиг знает. К примеру пришел код 400 на экране логина - это неверные данные, пришел код 400 на экране регистрации - это плохой пароль.

Также поменял логику в сетевом слое, как по мне было не очень читаемо. 